### PR TITLE
feat: support const and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tool for generation samples based on OpenAPI payload/response schema
 - deterministic (given a particular input, will always produce the same output)
 - Supports `allOf`
 - Supports `additionalProperties`
-- Uses `default`, `example` and `enum` where possible
+- Uses `default`, `const`, `enum` and `examples` where possible
 - Full array support: supports `minItems`, and tuples (`items` as an array)
 - Supports `minLength`, `maxLength`, `min`, `max`, `exclusiveMinimum`, `exclusiveMaximum`
 - Supports the next `string` formats:
@@ -32,7 +32,7 @@ Install using [npm](https://docs.npmjs.com/getting-started/what-is-npm)
 or using [yarn](https://yarnpkg.com)
 
     yarn add openapi-sampler
-    
+
 Then require it in your code:
 
 ```js

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -72,8 +72,12 @@ export function traverse(schema, options, spec) {
   let type = null;
   if (schema.default !== undefined) {
     example = schema.default;
+  } else if (schema.const !== undefined) {
+    example = schema.const;
   } else if (schema.enum !== undefined && schema.enum.length) {
     example = schema.enum[0];
+  } else if (schema.examples !== undefined && schema.examples.length) {
+    example = schema.examples[0];
   } else {
     type = schema.type;
     if (!type) {


### PR DESCRIPTION
const was added in JSON schema draft 6: https://json-schema.org/understanding-json-schema/reference/generic.html#constant-values
I see that "example" is supported on the OpenAPI level but it should also be supported in the JSON schema: https://json-schema.org/understanding-json-schema/reference/generic.html#annotations