### PR TITLE
deterministic date/date-time string sampler

### DIFF
--- a/src/samplers/string.js
+++ b/src/samplers/string.js
@@ -18,7 +18,7 @@ function passwordSample(min, max) {
 }
 
 function commonDateTimeSample(min, max, omitTime) {
-  let res = toRFCDateTime(new Date(), omitTime, false);
+  let res = toRFCDateTime(new Date("2019-08-24T14:15:22.123Z"), omitTime, false);
   if (res.length < min) {
     throw new Error(`Using minLength = ${min} is incorrect with format "date-time"`);
   }

--- a/test/unit/string.spec.js
+++ b/test/unit/string.spec.js
@@ -48,9 +48,19 @@ describe('sampleString', () => {
     expect(Date.parse(res)).not.to.be.NaN;
   });
 
+  it('should return deterministic date string for format date', () => {
+    res = sampleString({format: 'date'});
+    expect(res).to.equal("2019-08-24");
+  });
+
   it('should return date string for format date', () => {
     res = sampleString({format: 'date-time'});
     expect(Date.parse(res)).not.to.be.NaN;
+  });
+
+  it('should return deterministic date string for format date-time', () => {
+    res = sampleString({format: 'date-time'});
+    expect(res).to.equal("2019-08-24T14:15:22Z");
   });
 
   it('should throw if incorrect maxLength applied to date-time', () => {


### PR DESCRIPTION
make the output deterministic when sampling
a string with date/date-time format