### PR TITLE
Replace obsolete `jsnext:main` with `module`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-beta.16",
   "description": "Tool for generation samples based on OpenAPI payload/response schema",
   "main": "dist/openapi-sampler.js",
-  "jsnext:main": "src/openapi-sampler.js",
+  "module": "src/openapi-sampler.js",
   "scripts": {
     "test": "gulp",
     "lint": "gulp lint",


### PR DESCRIPTION
Hi,

Thank you for authoring this amazing package. This PR brings a small but important improvement to standardize ESM support. 

`jsnext:main` is obsolete and not used anymore as `module` came out as a standardized [solution to the same problem](https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for).

Every modern piece of tooling supports `module`, some also still support the obsolete `jsnext:main`. Not all of them though. 

For example I discovered the problem by attempting to write TypeScript definitions for the package (so TypeScript users can utilize it), and it turns out `dtslint` does not understand `jsnext:main`. Hence this PR.

I don't feel like it is worth keeping `jsnext:main`, because AFAIK every tool that supports `jsnext:main` also support the more standard `module` (except for maybe old-abandoned tools like Webpack v2). 