### PR TITLE
pass through required values from allOf level

### DIFF
--- a/src/allOf.js
+++ b/src/allOf.js
@@ -6,7 +6,7 @@ export function allOfSample(into, children, options, spec, context) {
   const subSamples = [];
 
   for (let subSchema of children) {
-    const { type, readOnly, writeOnly, value } = traverse({ type: res.type, ...subSchema }, options, spec, context);
+    const { type, readOnly, writeOnly, value } = traverse({ type: res.type, ...subSchema, required: into.required }, options, spec, context);
     if (res.type && type && type !== res.type) {
       console.warn('allOf: schemas with different types can\'t be merged');
       res.type = type;

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -141,6 +141,37 @@ describe('Integration', function() {
   });
 
   describe('AllOf', function() {
+    it('should handle allOf and required on the same level. (This is useful when using a $ref to specify a required param that is not required elsewhere.)', function() {
+      schema = {
+        'allOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'name': {
+                'type': 'string'
+              }
+            }
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'amount': {
+                'type': 'number',
+                'default': 2
+              }
+            }
+          }
+        ],
+        'required': [
+          'amount'
+        ]
+      };
+      result = OpenAPISampler.sample(schema, { skipNonRequired: true });
+      expected = {
+        'amount': 2
+      };
+      expect(result).to.deep.equal(expected);
+    })
     it('should sample schema with allOf', function() {
       schema = {
         'allOf': [


### PR DESCRIPTION
I have a use case in which I'm using the allOf discriminator to specify a required parameter that is not generally required for the schema. I was told this is a valid way to express this, though I cannot remember the source.

```
"schema": {
    "allOf": [
        {
            "$ref": "#/components/schemas/basicSchema"
        }
    ],
    "required": [
        "amount"
    ]
}
```