### PR TITLE
Feature: Don't auto generate sample for non-required object properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Available options:
   Don't include `readOnly` object properties
   - **skipWriteOnly** - `boolean`
   Don't include `writeOnly` object properties
+  - **disableAutoGeneration** - `boolean`
+  Don't auto generate sample when the schema hasn't explicit example nor default value
   - **quiet** - `boolean`
   Don't log console warning messages
 - **spec** - whole specification where the schema is taken from. Required only when schema may contain `$ref`. **spec** must not contain any external references

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Available options:
   Don't include `readOnly` object properties
   - **skipWriteOnly** - `boolean`
   Don't include `writeOnly` object properties
-  - **disableAutoGeneration** - `boolean`
-  Don't auto generate sample when the schema hasn't explicit example nor default value
+  - **disableNonRequiredAutoGen** - `boolean`
+  Don't auto generate sample for non-required object properties when the schema hasn't explicit example nor default value
   - **quiet** - `boolean`
   Don't log console warning messages
 - **spec** - whole specification where the schema is taken from. Required only when schema may contain `$ref`. **spec** must not contain any external references

--- a/src/samplers/array.js
+++ b/src/samplers/array.js
@@ -7,7 +7,7 @@ export function sampleArray(schema, options = {}, spec, context) {
     arrayLength = Math.max(arrayLength, schema.items.length);
   }
 
-  let itemSchemaGetter = itemNumber => {
+  const itemSchemaGetter = itemNumber => {
     if (Array.isArray(schema.items)) {
       return schema.items[itemNumber] || {};
     }
@@ -18,9 +18,13 @@ export function sampleArray(schema, options = {}, spec, context) {
   if (!schema.items) return res;
 
   for (let i = 0; i < arrayLength; i++) {
-    let itemSchema = itemSchemaGetter(i);
-    let { value: sample } = traverse(itemSchema, options, spec, {depth: depth + 1});
+    let { value: sample } = traverse(itemSchemaGetter(i), options, spec, {depth: depth + 1});
     res.push(sample);
   }
-  return res;
+
+  if (!options.omissible || res.some(item => item !== null)) {
+    return res;
+  }
+
+  return null;
 }

--- a/src/samplers/boolean.js
+++ b/src/samplers/boolean.js
@@ -1,3 +1,6 @@
-export function sampleBoolean(schema) {
+export function sampleBoolean(schema, options) {
+  if (options.disableAutoGeneration) {
+    return null;
+  }
   return true; // let be optimistic :)
 }

--- a/src/samplers/boolean.js
+++ b/src/samplers/boolean.js
@@ -1,5 +1,5 @@
-export function sampleBoolean(schema, options) {
-  if (options.disableAutoGeneration) {
+export function sampleBoolean(schema, options={}) {
+  if (options.omissible) {
     return null;
   }
   return true; // let be optimistic :)

--- a/src/samplers/number.js
+++ b/src/samplers/number.js
@@ -1,11 +1,10 @@
 export function sampleNumber(schema, options={}) {
-  if (options.disableAutoGeneration) {
+  if (options.omissible) {
     return null;
   }
 
-  let res;
   if (schema.maximum && schema.minimum) {
-    res = schema.exclusiveMinimum ? Math.floor(schema.minimum) + 1 : schema.minimum;
+    let res = schema.exclusiveMinimum ? Math.floor(schema.minimum) + 1 : schema.minimum;
     if ((schema.exclusiveMaximum && res >= schema.maximum) ||
       ((!schema.exclusiveMaximum && res > schema.maximum))) {
       res = (schema.maximum + schema.minimum) / 2;

--- a/src/samplers/number.js
+++ b/src/samplers/number.js
@@ -1,4 +1,8 @@
-export function sampleNumber(schema) {
+export function sampleNumber(schema, options={}) {
+  if (options.disableAutoGeneration) {
+    return null;
+  }
+
   let res;
   if (schema.maximum && schema.minimum) {
     res = schema.exclusiveMinimum ? Math.floor(schema.minimum) + 1 : schema.minimum;

--- a/src/samplers/object.js
+++ b/src/samplers/object.js
@@ -24,13 +24,21 @@ export function sampleObject(schema, options = {}, spec, context) {
       if (options.skipWriteOnly && sample.writeOnly) {
         return;
       }
-      res[propertyName] = sample.value;
+
+      if (sample.value || !options.disableAutoGeneration){
+        res[propertyName] = sample.value;
+      }
     });
   }
 
-  if (schema && typeof schema.additionalProperties === 'object') {
+  if (!options.disableAutoGeneration && schema && typeof schema.additionalProperties === 'object') {
     res.property1 = traverse(schema.additionalProperties, options, spec, {depth: depth + 1 }).value;
     res.property2 = traverse(schema.additionalProperties, options, spec, {depth: depth + 1 }).value;
   }
-  return res;
+
+  if (Object.keys(res).length > 0 || !options.disableAutoGeneration) {
+    return res;
+  }
+
+  return null;
 }

--- a/src/samplers/object.js
+++ b/src/samplers/object.js
@@ -4,19 +4,28 @@ export function sampleObject(schema, options = {}, spec, context) {
   const depth = (context && context.depth || 1);
 
   if (schema && typeof schema.properties === 'object') {
-    let requiredKeys = (Array.isArray(schema.required) ? schema.required : []);
-    let requiredKeyDict = requiredKeys.reduce((dict, key) => {
+    const requiredKeys = (Array.isArray(schema.required) ? schema.required : []);
+    const requiredKeyDict = requiredKeys.reduce((dict, key) => {
       dict[key] = true;
       return dict;
     }, {});
 
     Object.keys(schema.properties).forEach(propertyName => {
+      const isRequired = requiredKeyDict.hasOwnProperty(propertyName);
       // skip before traverse that could be costly
-      if (options.skipNonRequired && !requiredKeyDict.hasOwnProperty(propertyName)) {
+      if (options.skipNonRequired && !isRequired) {
         return;
       }
 
-      const sample = traverse(schema.properties[propertyName], options, spec, { propertyName, depth: depth + 1 });
+      const propertyOmissible = options.disableNonRequiredAutoGen && !isRequired;
+
+      const sample = traverse(
+        schema.properties[propertyName],
+        Object.assign({}, options, { omissible: propertyOmissible }),
+        spec,
+        { propertyName, depth: depth + 1 }
+      );
+
       if (options.skipReadOnly && sample.readOnly) {
         return;
       }
@@ -25,18 +34,18 @@ export function sampleObject(schema, options = {}, spec, context) {
         return;
       }
 
-      if (sample.value || !options.disableAutoGeneration){
+      if (sample.value || !propertyOmissible) {
         res[propertyName] = sample.value;
       }
     });
   }
 
-  if (!options.disableAutoGeneration && schema && typeof schema.additionalProperties === 'object') {
+  if (!options.disableNonRequiredAutoGen && schema && typeof schema.additionalProperties === 'object') {
     res.property1 = traverse(schema.additionalProperties, options, spec, {depth: depth + 1 }).value;
     res.property2 = traverse(schema.additionalProperties, options, spec, {depth: depth + 1 }).value;
   }
 
-  if (Object.keys(res).length > 0 || !options.disableAutoGeneration) {
+  if (Object.keys(res).length > 0 || !options.omissible) {
     return res;
   }
 

--- a/src/samplers/string.js
+++ b/src/samplers/string.js
@@ -78,6 +78,9 @@ const stringFormats = {
 };
 
 export function sampleString(schema, options, spec, context) {
+  if (options && options.disableAutoGeneration) {
+    return null;
+  }
   let format = schema.format || 'default';
   let sampler = stringFormats[format] || defaultSample;
   let propertyName = context && context.propertyName;

--- a/src/samplers/string.js
+++ b/src/samplers/string.js
@@ -78,7 +78,7 @@ const stringFormats = {
 };
 
 export function sampleString(schema, options, spec, context) {
-  if (options && options.disableAutoGeneration) {
+  if (options && options.omissible) {
     return null;
   }
   let format = schema.format || 'default';

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -92,7 +92,7 @@ export function traverse(schema, options, spec, context) {
     example = schema.default;
   } else if (schema.const !== undefined) {
     example = schema.const;
-  } else if (schema.enum !== undefined && schema.enum.length) {
+  } else if (schema.enum !== undefined && schema.enum.length && !options.disableNonRequiredAutoGen) {
     example = schema.enum[0];
   } else if (schema.examples !== undefined && schema.examples.length) {
     example = schema.examples[0];

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -405,6 +405,39 @@ describe('Integration', function() {
       expected = 'test1';
       expect(result).to.equal(expected);
     });
+
+    it('should use explicit example', function() {  // TODO: array
+      var obj = {
+        withExample: 'Example',
+      };
+      schema = {
+        type: 'object',
+        properties: {
+          withoutExampleString: {
+            type: 'string'
+          },
+          withoutExampleNumber: {
+            type: 'number'
+          },
+          withoutExampleBoolean: {
+            type: 'boolean'
+          },
+          withoutExampleObject: {
+            type: 'object',
+          },
+          withExample: {
+            type: 'string',
+            example: 'Example'
+          }
+        },
+        additionalProperties: {
+          type: 'number'
+        }
+      };
+      result = OpenAPISampler.sample(schema, { disableAutoGeneration: true });
+      expected = obj;
+      expect(result).to.deep.equal(obj);
+    });
   });
 
   describe('Detection', function() {

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -406,9 +406,10 @@ describe('Integration', function() {
       expect(result).to.equal(expected);
     });
 
-    it('should use explicit example', function() {  // TODO: array
+    it('should skip non-required properties without example if disableNonRequiredAutoGen=true', () => {
       var obj = {
         withExample: 'Example',
+        withExampleArray: [3],
       };
       schema = {
         type: 'object',
@@ -425,19 +426,41 @@ describe('Integration', function() {
           withoutExampleObject: {
             type: 'object',
           },
+          withoutExampleArray: {
+            type: 'array',
+            items: { type: 'string'}
+          },
           withExample: {
             type: 'string',
             example: 'Example'
+          },
+          withExampleArray: {
+            type: 'array',
+            items: { type: 'number', default: 3 }
           }
         },
         additionalProperties: {
           type: 'number'
         }
       };
-      result = OpenAPISampler.sample(schema, { disableAutoGeneration: true });
+      result = OpenAPISampler.sample(schema, { disableNonRequiredAutoGen: true });
       expected = obj;
       expect(result).to.deep.equal(obj);
     });
+
+    it('should return empty object if disableNonRequiredAutoGen=true and no explicit example', () => {
+      var obj = {};
+      schema = {
+        type: 'object',
+        properties: {
+          withoutExampleString: { type: 'string' },
+        }
+      };
+      result = OpenAPISampler.sample(schema, { disableNonRequiredAutoGen: true });
+      expected = obj;
+      expect(result).to.deep.equal(obj);
+    });
+
   });
 
   describe('Detection', function() {

--- a/test/unit/array.spec.js
+++ b/test/unit/array.spec.js
@@ -22,4 +22,45 @@ describe('sampleArray', () => {
     res = sampleArray({items: [{type: 'number'}, {type: 'string'}, {}]});
     expect(res).to.deep.equal([0, 'string', null]);
   });
+
+  describe('disableNonRequiredAutoGen', () => {
+
+    it('should return null if omissible=true and primitive type item has no example', () => {
+      res = sampleArray({ items: { type: 'string' } }, { omissible: true, disableNonRequiredAutoGen: true });
+      expect(res).to.be.null;
+    });
+
+    it('should return null if omssible=true and object type item has no example', () => {
+      res = sampleArray({
+        items: {
+          type: 'object',
+          properties: {
+            a: { type: 'string' },
+          },
+        }
+      }, { omissible: true, disableNonRequiredAutoGen: true });
+      expect(res).to.be.null;
+    });
+
+    it('should return valid array samples if omissible=false and primitive type item has no example', () => {
+      // the sample must be valid to schema and show the array item type when the array is not omitted
+      res = sampleArray({ items: { type: 'string' }, minItems: 2 }, { disableNonRequiredAutoGen: true });
+      expect(res).to.deep.equal(['string', 'string']);
+    });
+
+    it('should return array of empty object if omssible=false and object type item has no example', () => {
+      // the sample must be valid to schema and show the array item type when the array is not omitted
+      res = sampleArray({
+        items: {
+          type: 'object',
+          properties: {
+            a: { type: 'string' },
+          },
+        }
+      }, { disableNonRequiredAutoGen: true });
+      expect(res).to.deep.equal([{}]);
+    });
+
+  });
+
 });

--- a/test/unit/number.spec.js
+++ b/test/unit/number.spec.js
@@ -54,8 +54,8 @@ describe('sampleNumber', () => {
     expect(res).to.equal(3);
   });
 
-  it('should return null if disableAutoGeneration is true', () => {
-    res = sampleNumber({}, { disableAutoGeneration: true });
+  it('should return null if it is omissible', () => {
+    res = sampleNumber({}, { omissible: true });
     expect(res).to.be.null;
   });
 });

--- a/test/unit/number.spec.js
+++ b/test/unit/number.spec.js
@@ -53,4 +53,9 @@ describe('sampleNumber', () => {
     res = sampleNumber({minimum: 2, maximum: 3, exclusiveMinimum: true});
     expect(res).to.equal(3);
   });
+
+  it('should return null if disableAutoGeneration is true', () => {
+    res = sampleNumber({}, { disableAutoGeneration: true });
+    expect(res).to.be.null;
+  });
 });

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -104,39 +104,44 @@ describe('sampleObject', () => {
     });
   });
 
-  it('should skip properties without explicit example value if disableAutoGeneration=true', () => {
-    res = sampleObject({
-      properties: {
-        a: {type: 'string', enum: ['foo', 'bar']},
-        b: {type: 'integer', default: 100},
-        c: {type: 'string'}
-      },
-    }, {disableAutoGeneration: true});
-    expect(res).to.deep.equal({
-      a: 'foo',
-      b: 100
-    });
-  });
+  describe('disableNonRequiredAutoGen', () => {
 
-  it('should skip additional properties if disableAutoGeneration=true', () => {
-    res = sampleObject({
-      properties: {
-        a: {type: 'string', example: 'Example'},
-        additionalProperties: {type: 'string'}
-      },
-    }, {disableAutoGeneration: true});
-    expect(res).to.deep.equal({
-      a: 'Example'
+    it('should skip properties without explicit example value', () => {
+      res = sampleObject({
+        properties: {
+          a: { type: 'string', enum: ['foo', 'bar'] },
+          b: { type: 'integer', default: 100 },
+          c: { type: 'string' },
+          d: { type: 'string', example: 'Example' }
+        },
+      }, { disableNonRequiredAutoGen: true });
+      expect(res).to.deep.equal({
+        b: 100,
+        d: 'Example'
+      });
     });
-  });
 
-  it('should return null if disableAutoGeneration=true and no property has example', () => {
-    res = sampleObject({
-      properties: {
-        a: {type: 'string'},
-        b: {type: 'integer'}
-      },
-    }, {disableAutoGeneration: true});
-    expect(res).to.be.null;
+    it('should skip additional properties', () => {
+      res = sampleObject({
+        properties: {
+          a: { type: 'string', example: 'Example' },
+        },
+        additionalProperties: { type: 'string' }
+      }, { disableNonRequiredAutoGen: true });
+      expect(res).to.deep.equal({
+        a: 'Example'
+      });
+    });
+
+    it('should return null if omissible=true and no property has example', () => {
+      res = sampleObject({
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'integer' }
+        },
+      }, { disableNonRequiredAutoGen: true, omissible: true });
+      expect(res).to.be.null;
+    });
+
   });
 });

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -102,5 +102,41 @@ describe('sampleObject', () => {
       fooId: 'fb4274c7-4fcd-4035-8958-a680548957ff',
       barId: '3c966637-4898-4972-9a9d-baefa6cd6c89'
     });
-  })
+  });
+
+  it('should skip properties without explicit example value if disableAutoGeneration=true', () => {
+    res = sampleObject({
+      properties: {
+        a: {type: 'string', enum: ['foo', 'bar']},
+        b: {type: 'integer', default: 100},
+        c: {type: 'string'}
+      },
+    }, {disableAutoGeneration: true});
+    expect(res).to.deep.equal({
+      a: 'foo',
+      b: 100
+    });
+  });
+
+  it('should skip additional properties if disableAutoGeneration=true', () => {
+    res = sampleObject({
+      properties: {
+        a: {type: 'string', example: 'Example'},
+        additionalProperties: {type: 'string'}
+      },
+    }, {disableAutoGeneration: true});
+    expect(res).to.deep.equal({
+      a: 'Example'
+    });
+  });
+
+  it('should return null if disableAutoGeneration=true and no property has example', () => {
+    res = sampleObject({
+      properties: {
+        a: {type: 'string'},
+        b: {type: 'integer'}
+      },
+    }, {disableAutoGeneration: true});
+    expect(res).to.be.null;
+  });
 });

--- a/test/unit/string.spec.js
+++ b/test/unit/string.spec.js
@@ -105,4 +105,9 @@ describe('sampleString', () => {
     expect(res).to.match(UUID_REGEXP);
     expect(res).to.equal('fb4274c7-4fcd-4035-8958-a680548957ff');
   });
+
+  it('should return null if disableAutoGeneration is true', () => {
+    res = sampleString({}, { disableAutoGeneration: true });
+    expect(res).to.be.null;
+  });
 });

--- a/test/unit/string.spec.js
+++ b/test/unit/string.spec.js
@@ -106,8 +106,8 @@ describe('sampleString', () => {
     expect(res).to.equal('fb4274c7-4fcd-4035-8958-a680548957ff');
   });
 
-  it('should return null if disableAutoGeneration is true', () => {
-    res = sampleString({}, { disableAutoGeneration: true });
+  it('should return null if it is omissible', () => {
+    res = sampleString({}, { omissible: true });
     expect(res).to.be.null;
   });
 });


### PR DESCRIPTION
Add an option to disable sample auto generation for non-required object properties when the schema hasn't explicit example nor default value.

This MR is for https://github.com/Redocly/redoc/issues/1490#issuecomment-829965471