### PR TITLE
support for `x-additionalPropertiesName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tool for generation samples based on OpenAPI payload/response schema
 
 - Deterministic (given a particular input, will always produce the same output)
 - Supports compound keywords: `allOf`, `oneOf`, `anyOf`, `if/then/else`
-- Supports `additionalProperties`
+- Supports `additionalProperties` with [`x-additionalPropertiesName`](https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-additionalpropertiesname)
 - Uses `const`, `examples`, `enum` and `default` where possible - in this order
 - Good array support: supports `contains`, `minItems`, `maxItems`, and tuples (`items` as an array)
 - Supports `minLength`, `maxLength`, `min`, `max`, `exclusiveMinimum`, `exclusiveMaximum`

--- a/src/samplers/object.js
+++ b/src/samplers/object.js
@@ -29,8 +29,9 @@ export function sampleObject(schema, options = {}, spec, context) {
   }
 
   if (schema && typeof schema.additionalProperties === 'object') {
-    res.property1 = traverse(schema.additionalProperties, options, spec, {depth: depth + 1 }).value;
-    res.property2 = traverse(schema.additionalProperties, options, spec, {depth: depth + 1 }).value;
+    const propertyName = schema.additionalProperties['x-additionalPropertiesName'] || 'property';
+    res[`${String(propertyName)}1`] = traverse(schema.additionalProperties, options, spec, {depth: depth + 1 }).value;
+    res[`${String(propertyName)}2`] = traverse(schema.additionalProperties, options, spec, {depth: depth + 1 }).value;
   }
   return res;
 }

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -150,6 +150,14 @@ describe('sampleObject', () => {
     });
   });
 
+  it('should use custom property name when x-additionalPropertiesName is defined', () => {
+    res = sampleObject({additionalProperties: {type: 'string', 'x-additionalPropertiesName': 'attribute-name'}});
+    expect(res).to.deep.equal({
+      'attribute-name1': 'string',
+      'attribute-name2': 'string'
+    });
+  });
+
   it('should skip non-required properties if skipNonRequired=true', () => {
     res = sampleObject({
       properties: {


### PR DESCRIPTION
Solves #131 

## What/Why/How?

Support for `x-additionalPropertiesName` to define custom property names.

## Reference

[https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-additionalpropertiesname](https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-additionalpropertiesname)

## Testing

Passing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines