### PR TITLE
chore: switch back to json-pointer and use new version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "json-pointer-community": "^0.7.0"
+        "json-pointer": "0.6.2"
       },
       "devDependencies": {
         "@babel/core": "^7.7.2",
@@ -9451,10 +9451,10 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
-    "node_modules/json-pointer-community": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/json-pointer-community/-/json-pointer-community-0.7.0.tgz",
-      "integrity": "sha512-NZMjpx6mqI0ad9y48Qjo6xJ4eNueFmPWsmj+RP1UbfUncc9gJE01gzZo7HJQiT5Vz/V18MkjVmrk3I9Jf9P4xg==",
+    "node_modules/json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
       "dependencies": {
         "foreach": "^2.0.4"
       }
@@ -23260,10 +23260,10 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
-    "json-pointer-community": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/json-pointer-community/-/json-pointer-community-0.7.0.tgz",
-      "integrity": "sha512-NZMjpx6mqI0ad9y48Qjo6xJ4eNueFmPWsmj+RP1UbfUncc9gJE01gzZo7HJQiT5Vz/V18MkjVmrk3I9Jf9P4xg==",
+    "json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
       "requires": {
         "foreach": "^2.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
   },
   "dependencies": {
     "@types/json-schema": "^7.0.7",
-    "json-pointer-community": "0.7.0"
+    "json-pointer": "0.6.2"
   }
 }


### PR DESCRIPTION
The author of [json-pointer](https://github.com/manuelstofer/json-pointer/pull/36#issuecomment-1043032452) finally merged the CVE fix and pushed a release. 