### PR TITLE
fix: support circular oneOf/anyOf local props

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -32,7 +32,7 @@ export function mergeDeep(...objects) {
   const isObject = obj => obj && typeof obj === 'object';
 
   return objects.reduce((prev, obj) => {
-    Object.keys(obj).forEach(key => {
+    Object.keys(obj || {}).forEach(key => {
       const pVal = prev[key];
       const oVal = obj[key];
 

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -522,6 +522,40 @@ describe('Integration', function() {
         expected = 0;
         expect(result).to.equal(expected);
       });
+
+      it('should work with nested circular oneOf', function () {
+        result = OpenAPISampler.sample({ $ref: '#/definitions/A' }, {}, {
+          definitions: {
+            A: {
+              properties: {
+                a: { type: 'string' }
+              },
+              oneOf: [
+                { $ref: '#/definitions/A' }
+              ]
+            }
+          }
+        });
+        expected = { a: 'string' }
+        expect(result).to.deep.equal(expected);
+      });
+
+      it('should work with nested circular anyOf', function () {
+        result = OpenAPISampler.sample({ $ref: '#/definitions/A' }, {}, {
+          definitions: {
+            A: {
+              properties: {
+                a: { type: 'string' }
+              },
+              anyOf: [
+                { $ref: '#/definitions/A' }
+              ]
+            }
+          }
+        });
+        expected = { a: 'string' }
+        expect(result).to.deep.equal(expected);
+      });
     });
 
     describe('inferring type from root schema', function() {


### PR DESCRIPTION
## What/Why/How?

Circular oneOf/anyOf was loosing local properties.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines