### PR TITLE
chore: use prepublishOnly insted of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "gulp build",
     "build-dist": "gulp build",
     "coverage": "gulp coverage",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "files": [
     "src/",


### PR DESCRIPTION
## What/Why/How?
we should use `prepublishOnly`. Reason `prepublish` [deprecated](https://docs.npmjs.com/cli/v8/using-npm/scripts).
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines