### PR TITLE
Draft: fix: lost skip configuration effects when objects are in an allOf block

### DIFF
--- a/src/allOf.js
+++ b/src/allOf.js
@@ -1,12 +1,12 @@
 import { traverse } from './traverse';
 import { mergeDeep } from './utils';
 
-export function allOfSample(into, children, options, spec, context) {
-  let res = traverse(into, options, spec);
+export function allOfSample(into, children, options, spec, context, markForRemoval) {
+  let res = traverse(into, options, spec, null, markForRemoval);
   const subSamples = [];
 
   for (let subSchema of children) {
-    const { type, readOnly, writeOnly, value } = traverse({ type: res.type, ...subSchema }, options, spec, context);
+    const { type, readOnly, writeOnly, value } = traverse({ type: res.type, ...subSchema }, options, spec, context, markForRemoval);
     if (res.type && type && type !== res.type) {
       console.warn('allOf: schemas with different types can\'t be merged');
       res.type = type;

--- a/src/openapi-sampler.js
+++ b/src/openapi-sampler.js
@@ -1,5 +1,6 @@
 import { traverse, clearCache } from './traverse';
 import { sampleArray, sampleBoolean, sampleNumber, sampleObject, sampleString } from './samplers/index';
+import {removeForRemovalMarkedProperties} from './utils';
 
 export var _samplers = {};
 
@@ -11,7 +12,9 @@ const defaults = {
 export function sample(schema, options, spec) {
   let opts = Object.assign({}, defaults, options);
   clearCache();
-  return traverse(schema, opts, spec).value;
+
+  let traverseResult = traverse(schema, opts, spec, null, true);
+  return removeForRemovalMarkedProperties(traverseResult.value);
 };
 
 export function _registerSampler(type, sampler) {

--- a/src/samplers/array.js
+++ b/src/samplers/array.js
@@ -1,5 +1,5 @@
 import { traverse } from '../traverse';
-export function sampleArray(schema, options = {}, spec, context) {
+export function sampleArray(schema, options = {}, spec, context, markForRemoval) {
   const depth = (context && context.depth || 1);
 
   let arrayLength = Math.min(schema.maxItems != undefined ? schema.maxItems : Infinity, schema.minItems || 1);
@@ -21,7 +21,7 @@ export function sampleArray(schema, options = {}, spec, context) {
 
   for (let i = 0; i < arrayLength; i++) {
     let itemSchema = itemSchemaGetter(i);
-    let { value: sample } = traverse(itemSchema, options, spec, {depth: depth + 1});
+    let { value: sample } = traverse(itemSchema, options, spec, {depth: depth + 1}, markForRemoval);
     res.push(sample);
   }
   return res;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 export const MARKED_FOR_REMOVAL = {
-  time: new Date()
+  time: new Date() // some unique identifier
 };
 
 function pad(number) {
@@ -67,7 +67,8 @@ export function mergeDeep(...objects) {
         prev[key] = mergeDeep(pVal, oVal);
       } else {
         if (prev[key] === MARKED_FOR_REMOVAL) {
-          // do nothing. KEEP_REMOVED will be filtered out later before returning the sampling result.
+          // do nothing. MARKED_FOR_REMOVAL will be filtered out later
+          // before returning the sampling result.
         } else {
           prev[key] = oVal;
         }

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -1,4 +1,4 @@
-import { sampleObject} from '../../src/samplers/object.js';
+import {sampleObject} from '../../src/samplers';
 import {removeForRemovalMarkedProperties} from '../../src/utils';
 
 describe('sampleObject', () => {
@@ -24,6 +24,19 @@ describe('sampleObject', () => {
       a: {type: 'string'},
       b: {type: 'integer', readOnly: true}
     }}, {skipReadOnly: true});
+    expect(res).to.deep.equal({
+      a: 'string'
+    });
+  });
+
+  it('should skip readonly properties even if required skipReadOnly=true', () => {
+    res = sampleObject({
+      properties: {
+        a: {type: 'string'},
+        b: {type: 'integer', readOnly: true}
+      },
+      required: ['a', 'b']
+      }, {skipReadOnly: true});
     expect(res).to.deep.equal({
       a: 'string'
     });
@@ -130,6 +143,19 @@ describe('sampleObject', () => {
       a: {type: 'string'},
       b: {type: 'integer', writeOnly: true}
     }}, {skipWriteOnly: true});
+    expect(res).to.deep.equal({
+      a: 'string'
+    });
+  });
+
+  it('should skip writeOnly properties even if required and skipWriteOnly=true', () => {
+    res = sampleObject({
+      properties: {
+        a: {type: 'string'},
+        b: {type: 'integer', writeOnly: true}
+      },
+      required: ['a', 'b']
+    }, {skipWriteOnly: true});
     expect(res).to.deep.equal({
       a: 'string'
     });


### PR DESCRIPTION
## What/Why/How?

`readOnly` & `writeOnly` are not honored when they are set in an allOf block to edit an objects properties.

E.g. we got these components:

```yaml
components:
  schemas:
    User:
      type: object
      properties:
        id:
          type: integer
          readOnly: true
        tenant_id:
          type: integer
        username:
          type: string
    PatchUser:
      allOf:
        - $ref: '#/components/schemas/User'
        - type: object
          properties:
            tenant_id:
              readOnly: true
```


Assuming the `id` of a `User` will never change and `User` is used to create and read the user and `PatchUser` is used to update it, this setup would disallow to patch the tenant_id of a user, but keeps it writable when the user is created. Exactly that is not shown correctly in the request samples tab. It keeps showing the `tenant_id` in the request sample which implies it is updatable when it is not. The request body schema omits the tenant_id correctly. It is basically the same problem as here https://github.com/Redocly/redoc/issues/1238

This PR brings parity with the behaviour of https://github.com/swagger-api/swagger-codegen in such a case, which always honores `readOnly` & `writeOnly` in an allOf, regardless of the order of the elements.

## Reference

~~Fixes https://github.com/Redocly/redoc/issues/1238~~ Misunderstood something there. It is the same problem, not the same bug.

## Testing

Tests are added in this PR. I came across this bug in a personal project where I wanted to change the `readOnly` behaviour of a schema with an allOf block for a PATCH endpoint.

## Screenshots (optional)

## Check yourself

- [X] Code is linted
- [X] Tested
- [X] All new/updated code is covered with tests

## Security

- [X] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines