### PR TITLE
Fix lost skip configurations in allof blocks and readOnly and writeOnly in examples

### DIFF
--- a/src/allOf.js
+++ b/src/allOf.js
@@ -1,12 +1,12 @@
 import { traverse } from './traverse';
 import { mergeDeep } from './utils';
 
-export function allOfSample(into, children, options, spec, context) {
-  let res = traverse(into, options, spec);
+export function allOfSample(into, children, options, spec, context, markForRemoval) {
+  let res = traverse(into, options, spec, null, markForRemoval);
   const subSamples = [];
 
   for (let subSchema of children) {
-    const { type, readOnly, writeOnly, value } = traverse({ type: res.type, ...subSchema }, options, spec, context);
+    const { type, readOnly, writeOnly, value } = traverse({ type: res.type, ...subSchema }, options, spec, context, markForRemoval);
     if (res.type && type && type !== res.type) {
       console.warn('allOf: schemas with different types can\'t be merged');
       res.type = type;

--- a/src/openapi-sampler.js
+++ b/src/openapi-sampler.js
@@ -1,5 +1,6 @@
 import { traverse, clearCache } from './traverse';
 import { sampleArray, sampleBoolean, sampleNumber, sampleObject, sampleString } from './samplers/index';
+import {removeForRemovalMarkedProperties} from './utils';
 
 export var _samplers = {};
 
@@ -11,7 +12,9 @@ const defaults = {
 export function sample(schema, options, spec) {
   let opts = Object.assign({}, defaults, options);
   clearCache();
-  return traverse(schema, opts, spec).value;
+
+  let traverseResult = traverse(schema, opts, spec, null, true);
+  return removeForRemovalMarkedProperties(traverseResult.value);
 };
 
 export function _registerSampler(type, sampler) {

--- a/src/samplers/array.js
+++ b/src/samplers/array.js
@@ -1,5 +1,5 @@
 import { traverse } from '../traverse';
-export function sampleArray(schema, options = {}, spec, context) {
+export function sampleArray(schema, options = {}, spec, context, markForRemoval) {
   const depth = (context && context.depth || 1);
 
   let arrayLength = Math.min(schema.maxItems != undefined ? schema.maxItems : Infinity, schema.minItems || 1);
@@ -21,7 +21,7 @@ export function sampleArray(schema, options = {}, spec, context) {
 
   for (let i = 0; i < arrayLength; i++) {
     let itemSchema = itemSchemaGetter(i);
-    let { value: sample } = traverse(itemSchema, options, spec, {depth: depth + 1});
+    let { value: sample } = traverse(itemSchema, options, spec, {depth: depth + 1}, markForRemoval);
     res.push(sample);
   }
   return res;

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,26 @@ export function filterDeep(blueprint, check) {
   if (blueprint === undefined || blueprint === null || !Object.keys(blueprint).length) {
     return check;
   }
+  // If blueprint is:
+  //   * array of single value
+  //   * value is a primitive type
+  // and check value is:
+  //   * list of primitive types with same type
+  //
+  // return as valid for now
+  // TODO implement checks for every primitive type
+  if(Array.isArray(blueprint) && blueprint.length === 1 && isPrimitive(blueprint[0])) {
+    if(!Array.isArray(check)) {
+      // If value to be checked is no array, return nothing
+      return blueprint;
+    }
+    // Check if every value in array has same type
+    if(!check.every( (val, i, arr) => typeof val === typeof arr[0])) {
+      return blueprint;
+    }
+
+    return check;
+  }
 
   return Object.assign(...Object.keys(blueprint).map(key => {
     if (typeof blueprint[key] === 'object' && typeof check[key] === 'object') {
@@ -157,4 +177,12 @@ function jsf32(a, b, c, d) {
     d = a + t | 0;
     return (d >>> 0) / 4294967296;
   }
+}
+
+function isPrimitive(value) {
+  if(value === null){
+    return true;
+  }
+
+  return !(typeof value == 'object' || typeof value == 'function');
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 export const MARKED_FOR_REMOVAL = {
-  time: new Date()
+  time: new Date() // some unique identifier
 };
 
 function pad(number) {
@@ -67,7 +67,8 @@ export function mergeDeep(...objects) {
         prev[key] = mergeDeep(pVal, oVal);
       } else {
         if (prev[key] === MARKED_FOR_REMOVAL) {
-          // do nothing. KEEP_REMOVED will be filtered out later before returning the sampling result.
+          // do nothing. MARKED_FOR_REMOVAL will be filtered out later
+          // before returning the sampling result.
         } else {
           prev[key] = oVal;
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 export const MARKED_FOR_REMOVAL = {
+  type: 'REDOCLY_INTERNAL_MARKED_FOR_REMOVAL',
   time: new Date() // some unique identifier
 };
 

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -1,4 +1,4 @@
-import { sampleObject} from '../../src/samplers/object.js';
+import {sampleObject} from '../../src/samplers';
 import {removeForRemovalMarkedProperties} from '../../src/utils';
 
 describe('sampleObject', () => {
@@ -24,6 +24,19 @@ describe('sampleObject', () => {
       a: {type: 'string'},
       b: {type: 'integer', readOnly: true}
     }}, {skipReadOnly: true});
+    expect(res).to.deep.equal({
+      a: 'string'
+    });
+  });
+
+  it('should skip readonly properties even if required skipReadOnly=true', () => {
+    res = sampleObject({
+      properties: {
+        a: {type: 'string'},
+        b: {type: 'integer', readOnly: true}
+      },
+      required: ['a', 'b']
+      }, {skipReadOnly: true});
     expect(res).to.deep.equal({
       a: 'string'
     });
@@ -130,6 +143,19 @@ describe('sampleObject', () => {
       a: {type: 'string'},
       b: {type: 'integer', writeOnly: true}
     }}, {skipWriteOnly: true});
+    expect(res).to.deep.equal({
+      a: 'string'
+    });
+  });
+
+  it('should skip writeOnly properties even if required and skipWriteOnly=true', () => {
+    res = sampleObject({
+      properties: {
+        a: {type: 'string'},
+        b: {type: 'integer', writeOnly: true}
+      },
+      required: ['a', 'b']
+    }, {skipWriteOnly: true});
     expect(res).to.deep.equal({
       a: 'string'
     });


### PR DESCRIPTION
## What/Why/How?

The sampler ignores readOnly and writeOnly on properties in allOf's and in examples.

The problem with allOf's is that the readOnly and writeOnly information of properties is lost in them. This PR preserves the information by marking the properties with a special object `MARKED_FOR_REMOVAL` which were supposed to be removed by `skipNonRequired=true`, `skipReadOnly=true` or `skipWriteOnly=true`. Before the result is returned all values which are supposed to be removed are removed.

The problem with having example values in the sample even if they are readOnly or writeOnly is fixed by traversing the schema again for which the example is intended and removing all values which are invalid from the example.

## Reference

Fixes #140
Fixes https://github.com/Redocly/redoc/issues/1238

## Testing

Tests for the changes were added.

## Screenshots (optional)

## Check yourself

- [X] Code is linted
- [X] Tested
- [X] All new/updated code is covered with tests

## Security

- [X] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines