### PR TITLE
Use english for iri-reference sample

### DIFF
--- a/src/samplers/string.js
+++ b/src/samplers/string.js
@@ -77,11 +77,11 @@ function uriTemplateSample() {
 }
 
 function iriSample() {
-  return 'http://example.com';
+  return 'http://example.com/entity/1';
 }
 
 function iriReferenceSample() {
-  return '../словник';
+  return '/entity/1';
 }
 
 function uuidSample(_min, _max, propertyName) {


### PR DESCRIPTION
## What/Why/How?

A lot of sampler uses english, except the `iri-reference`, and english is more worlwide than ukrainian.

## Reference

## Testing

## Screenshots (optional)

![image](https://user-images.githubusercontent.com/1398469/196944639-1a775329-6b18-4c93-8036-1d6d44354bee.png)

