### PR TITLE
Fix oneOf being sampled twice for the first item in the list

### DIFF
--- a/src/samplers/array.js
+++ b/src/samplers/array.js
@@ -13,6 +13,9 @@ export function sampleArray(schema, options = {}, spec, context) {
     if (Array.isArray(items)) {
       return items[itemNumber] || {};
     }
+    if (items.oneOf && Array.isArray(items.oneOf)) {
+      return items.oneOf[itemNumber] || {};
+    }
     return items || {};
   };
 

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -183,4 +183,79 @@ describe('sampleObject', () => {
       barId: '3c966637-4898-4972-9a9d-baefa6cd6c89'
     });
   })
+
+  it('should generate both items of oneOf', () => {
+    res = sampleObject({
+      'type': 'object',
+      'properties': {
+        'my_obj': {
+          'type': 'object',
+          'properties': {
+            'elements': {
+              'items': {
+                'oneOf': [
+                  {
+                    'type': 'object',
+                    'properties': {
+                      'name': {
+                        'type': 'string',
+                        'description': '',
+                        'enum': [
+                          'obj_a'
+                        ]
+                      }
+                    },
+                    'title': 'obj_a',
+                    'required': [
+                      'name'
+                    ]
+                  },
+                  {
+                    'type': 'object',
+                    'properties': {
+                      'name': {
+                        'type': 'string',
+                        'description': '',
+                        'enum': [
+                          'obj_b'
+                        ]
+                      }
+                    },
+                    'title': 'obj_b',
+                    'required': [
+                      'name'
+                    ]
+                  }
+                ]
+              },
+              'type': 'array',
+              'minItems': 2,
+              'maxItems': 2,
+              'uniqueItems': true
+            }
+          },
+          'title': '',
+          'required': [
+            'elements'
+          ]
+        }
+      },
+      'required': [
+        'my_obj'
+      ]
+    })
+
+    expect(res).deep.equal({
+      'my_obj': {
+        'elements': [
+          {
+            'name': 'obj_a'
+          },
+          {
+            'name': 'obj_b'
+          }
+        ]
+      }
+    })
+  });
 });


### PR DESCRIPTION
## What/Why/How?

Details on this change can be found in the issue:
https://github.com/Redocly/openapi-sampler/issues/145

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines