### PR TITLE
fix: make number default to float

### DIFF
--- a/src/samplers/number.js
+++ b/src/samplers/number.js
@@ -1,6 +1,9 @@
 export function sampleNumber(schema) {
   let res = 0;
-  if (typeof schema.exclusiveMinimum === 'boolean' || typeof schema.exclusiveMaximum === 'boolean') { //legacy support for jsonschema draft 4 of exclusiveMaximum/exclusiveMinimum as booleans 
+  if (schema.type === 'number') {
+    res = 0.1;
+  }
+  if (typeof schema.exclusiveMinimum === 'boolean' || typeof schema.exclusiveMaximum === 'boolean') { //legacy support for jsonschema draft 4 of exclusiveMaximum/exclusiveMinimum as booleans
     if (schema.maximum && schema.minimum) {
       res = schema.exclusiveMinimum ? Math.floor(schema.minimum) + 1 : schema.minimum;
       if ((schema.exclusiveMaximum && res >= schema.maximum) ||

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -21,7 +21,7 @@ describe('Integration', function() {
         'type': 'number'
       };
       result = OpenAPISampler.sample(schema);
-      expected = 0;
+      expected = 0.1;
       expect(result).to.deep.equal(expected);
     });
 
@@ -160,8 +160,8 @@ describe('Integration', function() {
       result = OpenAPISampler.sample(schema);
       expected = {
         test: 'string',
-        property1: 0,
-        property2: 0
+        property1: 0.1,
+        property2: 0.1
       };
       expect(result).to.deep.equal(expected);
     });
@@ -384,7 +384,7 @@ describe('Integration', function() {
       expected = {
         parent: {
           child1: 'string',
-          child2: 0
+          child2: 0.1
         }
       };
 
@@ -469,7 +469,7 @@ describe('Integration', function() {
       expected = {
         foo: 'user@example.com',
         bar: 'string',
-        top: 0,
+        top: 0.1,
       };
       expect(result).to.deep.equal(expected);
     })
@@ -521,7 +521,7 @@ describe('Integration', function() {
           ]
         };
         result = OpenAPISampler.sample(schema);
-        expected = 0;
+        expected = 0.1;
         expect(result).to.equal(expected);
       });
 

--- a/test/unit/array.spec.js
+++ b/test/unit/array.spec.js
@@ -10,9 +10,9 @@ describe('sampleArray', () => {
 
   it('should return elements of correct type', () => {
     res = sampleArray({items: {type: 'number'}});
-    expect(res).to.deep.equal([0]);
+    expect(res).to.deep.equal([0.1]);
     res = sampleArray({contains: {type: 'number'}});
-    expect(res).to.deep.equal([0]);
+    expect(res).to.deep.equal([0.1]);
   });
 
   it('should return correct number of elements based on maxItems', () => {
@@ -22,16 +22,16 @@ describe('sampleArray', () => {
 
   it('should return correct number of elements based on minItems', () => {
     res = sampleArray({items: {type: 'number'}, minItems: 3});
-    expect(res).to.deep.equal([0, 0, 0]);
+    expect(res).to.deep.equal([0.1, 0.1, 0.1]);
   });
 
   it('should correctly sample tuples', () => {
     res = sampleArray({items: [{type: 'number'}, {type: 'string'}, {}]});
-    expect(res).to.deep.equal([0, 'string', null]);
+    expect(res).to.deep.equal([0.1, 'string', null]);
   });
 
   it('should correctly sample tuples for 3.1', () => {
     res = sampleArray({prefixItems: [{type: 'number'}, {type: 'string'}, {}]});
-    expect(res).to.deep.equal([0, 'string', null]);
+    expect(res).to.deep.equal([0.1, 'string', null]);
   });
 });

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -39,7 +39,7 @@ describe('sampleObject', () => {
     expect(res).to.deep.equal({
       a: 'string',
       b: {
-        b2: 0
+        b2: 0.1
       }
     });
   });
@@ -101,7 +101,7 @@ describe('sampleObject', () => {
     expect(res).to.deep.equal({
       a: 'string',
       b: {
-        b2: 0
+        b2: 0.1
       }
     });
   });


### PR DESCRIPTION
## What/Why/How?
Schemas with type `number` should always be sampled with a double or float, and not an integer. According to the OpenAPI spec, the format of a number is either a double or a float. 

## Reference
https://spec.openapis.org/oas/v3.1.0#data-types

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines