### PR TITLE
Update requite syntax to match example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ or using [yarn](https://yarnpkg.com)
 Then require it in your code:
 
 ```js
-var OpenAPISampler = require('openapi-sampler');
+const OpenAPISampler = require('.');
 ```
 
 ## Usage


### PR DESCRIPTION
Update provided require syntax in README.md to be consistent with the example given at the bottom of the page that uses more up-to-date JS syntax.