### PR TITLE
feat: add enablePatterns config option

### DIFF
--- a/src/samplers/string.js
+++ b/src/samplers/string.js
@@ -43,8 +43,8 @@ function timeSample(min, max) {
   return commonDateTimeSample({ min, max, omitTime: false, omitDate: true }).slice(1);
 }
 
-function defaultSample(min, max, _propertyName, pattern) {
-  if (pattern) {
+function defaultSample(min, max, _propertyName, pattern, enablePatterns = false) {
+  if (pattern && enablePatterns) {
     return faker.regexSample(pattern);
   }
   let res = ensureMinLength('string', min);
@@ -136,5 +136,6 @@ export function sampleString(schema, options, spec, context) {
     schema.maxLength,
     propertyName,
     schema.pattern,
+    options?.enablePatterns
   );
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,6 +5,7 @@ export interface Options {
   readonly skipReadOnly?: boolean;
   readonly skipWriteOnly?: boolean;
   readonly quiet?: boolean;
+  readonly enablePatterns?: boolean
 }
 
 export function sample(schema: JSONSchema7, options?: Options, document?: object): unknown;

--- a/test/unit/string.spec.js
+++ b/test/unit/string.spec.js
@@ -135,7 +135,7 @@ describe('sampleString', () => {
       .forEach((regexp) => {
         res = sampleString(
           {pattern: regexp.source},
-          null,
+          {enablePatterns: true},
           null,
           {propertyName: 'fooId'},
         );


### PR DESCRIPTION
## What/Why/How?
feat: add enablePatterns config option

Recently, we have added pattern generation for string values but it does not cover all regex causes. So we decided to add a new config option in order to handle it properly. By default,  pattern generation is disabled.
## Reference
https://github.com/Redocly/openapi-sampler/pull/153
## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines