### PR TITLE
feat: add support xml samples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
+        "fast-xml-parser": "^4.5.0",
         "json-pointer": "0.6.2"
       },
       "devDependencies": {
@@ -6204,6 +6205,27 @@
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
       "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
+      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -13437,6 +13459,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/subarg": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "@types/json-schema": "^7.0.7",
+    "fast-xml-parser": "^4.5.0",
     "json-pointer": "0.6.2"
   },
   "overrides": {

--- a/src/openapi-sampler.js
+++ b/src/openapi-sampler.js
@@ -1,5 +1,13 @@
 import { traverse, clearCache } from './traverse';
 import { sampleArray, sampleBoolean, sampleNumber, sampleObject, sampleString } from './samplers/index';
+import { XMLBuilder } from 'fast-xml-parser';
+
+const builder = new XMLBuilder({
+  ignoreAttributes : false,
+  format: true,
+  attributeNamePrefix: '$',
+  textNodeName: '#text',
+});
 
 export var _samplers = {};
 
@@ -11,7 +19,14 @@ const defaults = {
 export function sample(schema, options, spec) {
   let opts = Object.assign({}, defaults, options);
   clearCache();
-  return traverse(schema, opts, spec).value;
+  let result = traverse(schema, opts, spec).value;
+  if (opts.format === 'xml') {
+    if (Object.keys(result).length > 1) {
+      result = { [schema?.xml?.name || 'root']: result };
+    }
+    return builder.build(result);
+  }
+  return result;
 };
 
 export function _registerSampler(type, sampler) {

--- a/src/samplers/array.js
+++ b/src/samplers/array.js
@@ -1,4 +1,6 @@
 import { traverse } from '../traverse';
+import { applyXMLAttributes } from '../utils';
+
 export function sampleArray(schema, options = {}, spec, context) {
   const depth = (context && context.depth || 1);
 
@@ -22,7 +24,19 @@ export function sampleArray(schema, options = {}, spec, context) {
   for (let i = 0; i < arrayLength; i++) {
     let itemSchema = itemSchemaGetter(i);
     let { value: sample } = traverse(itemSchema, options, spec, {depth: depth + 1});
-    res.push(sample);
+    if (options?.format === 'xml') {
+      const { value, propertyName } = applyXMLAttributes({value: sample}, itemSchema);
+      if (propertyName) {
+        if (!res?.[propertyName]) {
+          res = { ...res, [propertyName]: [] };
+        }
+        res[propertyName].push(value);
+      } else {
+        res.push(sample);
+      }
+    } else {
+      res.push(sample);
+    }
   }
   return res;
 }

--- a/src/samplers/object.js
+++ b/src/samplers/object.js
@@ -1,4 +1,6 @@
 import { traverse } from '../traverse';
+import { applyXMLAttributes } from '../utils';
+
 export function sampleObject(schema, options = {}, spec, context) {
   let res = {};
   const depth = (context && context.depth || 1);
@@ -27,7 +29,17 @@ export function sampleObject(schema, options = {}, spec, context) {
       if (options.skipWriteOnly && sample.writeOnly) {
         return;
       }
-      res[propertyName] = sample.value;
+
+      if (options?.format === 'xml') {
+        const { propertyName: newPropertyName, value } = applyXMLAttributes(sample, schema.properties[propertyName], {propertyName});
+        if (newPropertyName) {
+          res[newPropertyName] = value;
+        } else {
+          res = { ...res, ...value };
+        }
+      } else {
+        res[sample.propertyName] = sample.value;
+      }
     });
   }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,7 +5,8 @@ export interface Options {
   readonly skipReadOnly?: boolean;
   readonly skipWriteOnly?: boolean;
   readonly quiet?: boolean;
-  readonly enablePatterns?: boolean
+  readonly enablePatterns?: boolean;
+  readonly format?: 'json' | 'xml';
 }
 
 export function sample(schema: JSONSchema7, options?: Options, document?: object): unknown;

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,6 +71,59 @@ export function popSchemaStack(seenSchemasStack, context) {
   if (context) seenSchemasStack.pop();
 }
 
+export function getXMLAttributes(schema) {
+  return {
+    name: schema?.xml?.name || '',
+    prefix: schema?.xml?.prefix || '',
+    namespace: schema?.xml?.namespace || null,
+    attribute: schema?.xml?.attribute ?? false,
+    wrapped: schema?.xml?.wrapped ?? false,
+  };
+}
+
+export function applyXMLAttributes(result, schema, context) {
+  const { value: oldValue } = result;
+  const { propertyName: oldPropertyName } = context || {};
+  const { name, prefix, namespace, attribute, wrapped } =
+    getXMLAttributes(schema);
+  let propertyName = name || oldPropertyName ? `${prefix ? prefix + ':' : ''}${name || oldPropertyName}` : null;
+
+  let value = typeof oldValue === 'object'
+    ? Array.isArray(oldValue)
+    ? [...oldValue]
+    : { ...oldValue }
+    : oldValue;
+
+  if (attribute && propertyName) {
+    propertyName = `$${propertyName}`;
+  }
+
+  if (namespace) {
+    if (typeof value === 'object') {
+      value[`$xmlns${prefix ? ':' + prefix : ''}`] = namespace;
+    } else {
+      value = { [`$xmlns${prefix ? ':' + prefix : ''}`]: namespace, ['#text']: value };
+    }
+  }
+
+  if (schema.type === 'array') {
+    if (wrapped && Array.isArray(value)) {
+      value = { [propertyName]: [...value] };
+    } else if (!wrapped) {
+      propertyName = null;
+    }
+
+    if (schema.example !== undefined && !wrapped) {
+      propertyName = schema.items.xml?.name || propertyName;
+    }
+  }
+
+  return {
+    propertyName,
+    value,
+  };
+}
+
 function hashCode(str) {
   var hash = 0;
   if (str.length == 0) return hash;

--- a/test/unit/sampler.spec.js
+++ b/test/unit/sampler.spec.js
@@ -1,0 +1,478 @@
+import { sample } from '../../src/openapi-sampler.js';
+
+const options = {
+  format: 'xml',
+};
+
+describe('sample', () => {
+
+  it('should build XML for an array with wrapped elements without examples', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string', xml: { name: 'book' } },
+          xml: { wrapped: true, name: 'booksLibrary' },
+        },
+      },
+    };
+    const result = sample(schema, options, {});
+
+    expect(result.trim()).toMatchInlineSnapshot(`
+"<booksLibrary>
+  <book>string</book>
+</booksLibrary>"
+`);
+  });
+
+  it('should build XML for an array with unwrapped elements without examples', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string', xml: { name: 'book' } },
+          xml: { wrapped: false },
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result.trim()).toMatchInlineSnapshot(`"<book>string</book>"`);
+  });
+
+  it('should build XML for an array with wrapped parent name and undefined item name', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string' },
+          xml: { wrapped: true, name: 'booksLibrary' },
+          example: ['test1', 'test2'],
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result.trim()).toMatchInlineSnapshot(`
+"<booksLibrary>
+  <booksLibrary>test1</booksLibrary>
+  <booksLibrary>test2</booksLibrary>
+</booksLibrary>"
+`);
+  });
+
+  it('should build XML for an array with wrapped parent and defined item name', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string', xml: { name: 'book' } },
+          xml: { wrapped: true, name: 'booksLibrary' },
+          example: ['test1', 'test2'],
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+    expect(result.trim()).toMatchInlineSnapshot(`
+"<booksLibrary>
+  <booksLibrary>test1</booksLibrary>
+  <booksLibrary>test2</booksLibrary>
+</booksLibrary>"
+`);
+  });
+
+  it('should build XML for an array with undefined parent and item names', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string' },
+          xml: { wrapped: true },
+          example: ['test1', 'test2'],
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result.trim()).toMatchInlineSnapshot(`
+"<books>
+  <books>test1</books>
+  <books>test2</books>
+</books>"
+`);
+  });
+
+  it('should build XML for an array with undefined parent name and defined item name', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string', xml: { name: 'book' } },
+          xml: { wrapped: true },
+          example: ['test1', 'test2'],
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+    expect(result.trim()).toMatchInlineSnapshot(`
+"<books>
+  <books>test1</books>
+  <books>test2</books>
+</books>"
+`);
+  });
+
+  it('should build XML for an array with defined parent and undefined item names', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string' },
+          xml: { name: 'booksLibrary' }, // it is ignored because wrapped is false by default
+          example: ['test1', 'test2'],
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result).toMatchInlineSnapshot(`
+"<root>
+  <0>test1</0>
+  <1>test2</1>
+</root>
+"
+`);
+  });
+
+  it('should build XML for an array with defined parent and item names', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string', xml: { name: 'book' } },
+          xml: { name: 'booksLibrary' },
+          example: ['test1', 'test2'],
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result).toMatchInlineSnapshot(`
+"<book>test1</book>
+<book>test2</book>
+"
+`);
+  });
+
+  it('should build XML for an array with undefined parent and defined item names without wrapper', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string', xml: { name: 'book' } },
+          example: ['test1', 'test2'],
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result).toMatchInlineSnapshot(`
+"<book>test1</book>
+<book>test2</book>
+"
+`);
+  });
+
+  it('should build XML for an array with correct item prefix logic', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        books: {
+          type: 'array',
+          items: { type: 'string', xml: { prefix: 'child' } },
+          xml: {
+            wrapped: true,
+            name: 'booksLibrary',
+            prefix: 'parent',
+          },
+        },
+      },
+    };
+    const result = sample(schema, options, {});
+
+    expect(result).toMatchInlineSnapshot(`
+"<parent:booksLibrary>
+  <parent:booksLibrary>string</parent:booksLibrary>
+</parent:booksLibrary>
+"
+`);
+  });
+
+  it('should build XML for an nested object', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        location: {
+          type: 'object',
+          properties: {
+            city: {
+              type: 'string',
+              xml: {
+                name: 'eventCity',
+                prefix: 'loc',
+              },
+              example: 'Atlantis',
+            },
+            index: {
+              type: 'integer',
+              xml: {
+                name: 'id',
+                prefix: 'index',
+              },
+              example: '123',
+            },
+            places: {
+              type: 'array',
+              items: {
+                type: 'string',
+                xml: {
+                  name: 'eventPlaces',
+                },
+              },
+              example: ['place1', 'place2'],
+            },
+          },
+          xml: {
+            name: 'eventLocation',
+            prefix: 'loc',
+          },
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result).toMatchInlineSnapshot(`
+"<loc:eventLocation>
+  <loc:eventCity>Atlantis</loc:eventCity>
+  <index:id>123</index:id>
+  <eventPlaces>place1</eventPlaces>
+  <eventPlaces>place2</eventPlaces>
+</loc:eventLocation>
+"
+`);
+  });
+
+  it('should build XML for an nested object without examples', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        location: {
+          type: 'object',
+          properties: {
+            city: {
+              type: 'string',
+              xml: {
+                name: 'eventCity',
+                prefix: 'loc',
+              },
+            },
+            index: {
+              type: 'integer',
+              xml: {
+                name: 'id',
+                prefix: 'index',
+              },
+            },
+            places: {
+              type: 'array',
+              items: {
+                type: 'string',
+                xml: {
+                  name: 'eventPlaces',
+                },
+              },
+            },
+          },
+          xml: {
+            name: 'eventLocation',
+            prefix: 'loc',
+          },
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result).toMatchInlineSnapshot(`
+"<loc:eventLocation>
+  <loc:eventCity>string</loc:eventCity>
+  <index:id>0</index:id>
+  <eventPlaces>string</eventPlaces>
+</loc:eventLocation>
+"
+`);
+  });
+
+  it('should build XML for an nested object with namespace', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        location: {
+          type: 'object',
+          properties: {
+            city: {
+              type: 'string',
+              xml: {
+                name: 'eventCity',
+                prefix: 'c',
+                namespace: 'http://example.com/city',
+              },
+              example: 'Atlantis',
+            },
+          },
+          xml: {
+            name: 'eventLocation',
+            prefix: 'l',
+            namespace: 'http://example.com/location',
+          },
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result).toMatchInlineSnapshot(`
+"<l:eventLocation xmlns:l="http://example.com/location">
+  <c:eventCity xmlns:c="http://example.com/city">Atlantis</c:eventCity>
+</l:eventLocation>
+"
+`);
+  });
+
+  it('should build XML for an nested object when all properties are attributes', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        location: {
+          type: 'object',
+          properties: {
+            coordinates: {
+              type: 'object',
+              properties: {
+                lat: {
+                  type: 'number',
+                  xml: {
+                    name: 'latitude',
+                    prefix: 'loc',
+                    attribute: true,
+                  },
+                  example: 12.345,
+                },
+                long: {
+                  type: 'number',
+                  xml: {
+                    attribute: true,
+                    name: 'longitude',
+                    prefix: 'loc',
+                  },
+                  example: 67.89,
+                },
+              },
+              xml: {
+                name: 'geoCoordinates',
+                prefix: 'geo',
+              },
+            },
+          },
+          xml: {
+            name: 'eventLocation',
+            prefix: 'loc',
+          },
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result).toMatchInlineSnapshot(`
+"<loc:eventLocation>
+  <geo:geoCoordinates loc:latitude="12.345" loc:longitude="67.89"></geo:geoCoordinates>
+</loc:eventLocation>
+"
+`);
+  });
+
+  it('should build XML for an nested object when one of the property is attribute', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        location: {
+          type: 'object',
+          properties: {
+            coordinates: {
+              type: 'object',
+              properties: {
+                lat: {
+                  type: 'number',
+                  xml: {
+                    name: 'latitude',
+                    prefix: 'loc',
+                    attribute: true,
+                  },
+                  example: 12.345,
+                },
+                long: {
+                  type: 'number',
+                  xml: {
+                    attribute: false,
+                    name: 'longitude',
+                    prefix: 'loc',
+                  },
+                  example: 67.89,
+                },
+              },
+              xml: {
+                name: 'geoCoordinates',
+                prefix: 'geo',
+              },
+            },
+          },
+          xml: {
+            name: 'eventLocation',
+            prefix: 'loc',
+          },
+        },
+      },
+    };
+
+    const result = sample(schema, options, {});
+
+    expect(result).toMatchInlineSnapshot(`
+"<loc:eventLocation>
+  <geo:geoCoordinates loc:latitude="12.345">
+    <loc:longitude>67.89</loc:longitude>
+  </geo:geoCoordinates>
+</loc:eventLocation>
+"
+`);
+  });
+});
+


### PR DESCRIPTION
## What/Why/How?
add XML support into sampler. 

Introduce new option `format:xml/json`
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines