### PR TITLE
fix: undefined error for xml when example is defined

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -115,7 +115,7 @@ export function applyXMLAttributes(result, schema = {}, context = {}) {
     }
 
     if (schema.example !== undefined && !wrapped) {
-      propertyName = schema.items.xml?.name || propertyName;
+      propertyName = schema.items?.xml?.name || propertyName;
     }
   }
   if (schema.oneOf || schema.anyOf || schema.allOf || schema.$ref) {

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -881,6 +881,30 @@ describe('Integration', () => {
     const options = {
       format: 'xml',
     };
+
+    it('should build XML for an array with nested array', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'array',
+            items: {
+              type: 'string',
+              example: ['John', 'Smith'],
+            }
+          }
+        }
+      };
+      const result = sample(schema, options, {});
+
+      expect(result.trim()).toMatchInlineSnapshot(`
+"<name>
+  <0>John</0>
+  <1>Smith</1>
+</name>"
+`);
+    });
+
     it('should build XML for an array with wrapped elements without examples', () => {
       const schema = {
         type: 'object',


### PR DESCRIPTION
## What/Why/How?
fix an undefined error for case when example is exists
```
{
        type: 'object',
        properties: {
          name: {
            type: 'array',
            items: {
              type: 'string',
              example: ['John', 'Smith'],
            }
          }
        }
      }
```
## Reference

## Testing

## Screenshots (optional)
<img width="1290" alt="Screenshot 2024-11-29 at 17 21 44" src="https://github.com/user-attachments/assets/d52a254e-24e5-46ce-be8d-ce65f7e67adc">

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines