### PR TITLE
Handled anchors and added tests for regex

### DIFF
--- a/src/samplers/string-regex.js
+++ b/src/samplers/string-regex.js
@@ -186,7 +186,9 @@ export function regexSample(pattern) {
     pattern = pattern.toString();
     pattern = pattern.match(/\/(.+?)\//)?.[1] ?? ''; // Remove frontslash from front and back of RegExp
   }
-
+  
+  pattern = pattern.replace(/^(\^)?(.*?)(\$)?$/, '$2'); // Remove anchors if present
+  
   let min
   let max
   let repetitions

--- a/test/unit/string.spec.js
+++ b/test/unit/string.spec.js
@@ -123,7 +123,7 @@ describe('sampleString', () => {
   });
 
   it('should generate valid text for basic regexes', () => {
-    [/#{3}test[1-5]/, /[500-15000]/, /#{2,9}/, /#{5}/, /0x[0-9a-f]{40}/]
+    [/#{3}test[1-5]/, /[500-15000]/, /#{2,9}/, /#{5}/, /0x[0-9a-f]{40}/, /^[0-9]$/]
       .forEach((regexp) => {
         res = sampleString(
           {pattern: regexp.source},


### PR DESCRIPTION
## What/Why/How?

Schemas with type string should generate a valid regex if common anchors like ^ or $ are used in pattern.

## Reference

#178 

## Testing

Added additional case to test regex with anchors

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines