### PR TITLE
fix: resolve falsy zero bug in sampleNumber function and add related tests

### DIFF
--- a/.changeset/zero-numeric-boundaries.md
+++ b/.changeset/zero-numeric-boundaries.md
@@ -1,0 +1,5 @@
+---
+"openapi-sampler": patch
+---
+
+Fixed generated samples that violated the schema when a numeric boundary was `0`.

--- a/src/samplers/number.js
+++ b/src/samplers/number.js
@@ -4,7 +4,7 @@ export function sampleNumber(schema) {
     res = 0.1;
   }
   if (typeof schema.exclusiveMinimum === 'boolean' || typeof schema.exclusiveMaximum === 'boolean') { //legacy support for jsonschema draft 4 of exclusiveMaximum/exclusiveMinimum as booleans
-    if (schema.maximum && schema.minimum) {
+    if (Number.isFinite(schema.maximum) && Number.isFinite(schema.minimum)) {
       res = schema.exclusiveMinimum ? Math.floor(schema.minimum) + 1 : schema.minimum;
       if ((schema.exclusiveMaximum && res >= schema.maximum) ||
         ((!schema.exclusiveMaximum && res > schema.maximum))) {
@@ -12,14 +12,14 @@ export function sampleNumber(schema) {
       }
       return res;
     }
-    if (schema.minimum) {
+    if (Number.isFinite(schema.minimum)) {
       if (schema.exclusiveMinimum) {
         return Math.floor(schema.minimum) + 1;
       } else {
         return schema.minimum;
       }
     }
-    if (schema.maximum) {
+    if (Number.isFinite(schema.maximum)) {
       if (schema.exclusiveMaximum) {
         return (schema.maximum > 0) ? 0 : Math.floor(schema.maximum) - 1;
       } else {
@@ -27,18 +27,18 @@ export function sampleNumber(schema) {
       }
     }
   } else {
-    if (schema.minimum) {
+    if (Number.isFinite(schema.minimum)) {
       return schema.minimum;
     }
-    if (schema.exclusiveMinimum) {
+    if (Number.isFinite(schema.exclusiveMinimum)) {
       res = Math.floor(schema.exclusiveMinimum) + 1;
 
       if (res === schema.exclusiveMaximum) {
         res = (res + Math.floor(schema.exclusiveMaximum) - 1) / 2;
       }
-    } else if (schema.exclusiveMaximum) {
+    } else if (Number.isFinite(schema.exclusiveMaximum)) {
       res = Math.floor(schema.exclusiveMaximum) - 1;
-    } else if (schema.maximum) {
+    } else if (Number.isFinite(schema.maximum)) {
       res = schema.maximum;
     }
   }

--- a/test/unit/number.spec.js
+++ b/test/unit/number.spec.js
@@ -42,4 +42,55 @@ describe('sampleNumber', () => {
     res = sampleNumber({exclusiveMinimum: 8, exclusiveMaximum: 13});
     expect(res).toBe(9);
   });
+
+  it('should return a value above exclusiveMinimum of 0 for draft v7', () => {
+    res = sampleNumber({exclusiveMinimum: 0});
+    expect(res).toBe(1);
+  });
+
+  it('should return a value below exclusiveMaximum of 0 for draft v7', () => {
+    res = sampleNumber({exclusiveMaximum: 0});
+    expect(res).toBe(-1);
+  });
+
+  it('should return middle point if exclusiveMinimum is 0 and boundary integer is not possible for draft v7', () => {
+    res = sampleNumber({exclusiveMinimum: 0, exclusiveMaximum: 1});
+    expect(res).toBe(0.5);
+  });
+
+  it('should return minimum of 0 if both minimum and maximum are specified', () => {
+    res = sampleNumber({minimum: 0, maximum: 10});
+    expect(res).toBe(0);
+  });
+
+  it('should respect minimum of 0 for float type', () => {
+    res = sampleNumber({type: 'number', format: 'float', minimum: 0});
+    expect(res).toBe(0);
+  });
+
+  it('should respect maximum of 0 for float type', () => {
+    res = sampleNumber({type: 'number', format: 'float', maximum: 0});
+    expect(res).toBe(0);
+  });
+
+  it('should return minimum + 1 if minimum is 0 and exclusiveMinimum is true for draft v4', () => {
+    res = sampleNumber({minimum: 0, exclusiveMinimum: true});
+    expect(res).toBe(1);
+  });
+
+  it('should return maximum - 1 if maximum is 0 and exclusiveMaximum is true for draft v4', () => {
+    res = sampleNumber({maximum: 0, exclusiveMaximum: true});
+    expect(res).toBe(-1);
+  });
+
+  it('should exclude minimum of 0 if maximum is also specified for draft v4', () => {
+    res = sampleNumber({minimum: 0, maximum: 10, exclusiveMinimum: true});
+    expect(res).toBe(1);
+  });
+
+  it('should ignore boundaries that are not finite numbers', () => {
+    expect(sampleNumber({exclusiveMinimum: null})).toBe(0);
+    expect(sampleNumber({minimum: null})).toBe(0);
+    expect(sampleNumber({exclusiveMinimum: NaN})).toBe(0);
+  });
 });


### PR DESCRIPTION
## What/Why/How?
Replaced the truthiness tests on numeric boundary keywords with `Number.isFinite()`, so a boundary of `0` (such as `exclusiveMinimum: 0`) is no longer treated as absent. 
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines